### PR TITLE
[12.x] Add `ensureRelationLoaded()` method to Eloquent Model

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
@@ -1073,6 +1074,30 @@ trait HasRelationships
     public function relationLoaded($key)
     {
         return array_key_exists($key, $this->relations);
+    }
+
+    /**
+     * Validates whether the given relation is loaded.
+     *
+     * @param  string  $relation
+     * @return void
+     */
+    public function ensureRelationLoaded(string $relation): void
+    {
+        [$immediateRelation, $childRelation] = array_replace(
+            [null, null],
+            explode('.', $relation, 2),
+        );
+
+        if (! $this->relationLoaded($immediateRelation)) {
+            throw new LazyLoadingViolationException(model: $this, relation: $immediateRelation);
+        }
+
+        if ($childRelation) {
+            foreach ($this->$immediateRelation as $related) {
+                $related->ensureRelationLoaded($childRelation);
+            }
+        }
     }
 
     /**

--- a/tests/Integration/Database/EloquentEnsureEagerLoadedTest.php
+++ b/tests/Integration/Database/EloquentEnsureEagerLoadedTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentEnsureEagerLoadedTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\LazyLoadingViolationException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentEnsureEagerLoadedTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('ones', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('twos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('threes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('two_id');
+        });
+    }
+
+    public function testWhenRelationNotLoaded()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+
+        $model = One::query()->find($one->id);
+
+        $this->expectLazyLoadingViolationException(One::class, 'twos');
+        $model->ensureRelationLoaded('twos');
+    }
+
+    public function testWhenRelationLoaded()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+
+        $model = One::query()
+            ->with('twos')
+            ->find($one->id);
+
+        $model->ensureRelationLoaded('twos');
+    }
+
+    public function testWhenChildRelationIsNotLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+
+        $model = One::query()
+            ->with('twos')
+            ->find($one->id);
+
+        $this->expectLazyLoadingViolationException(Two::class, 'threes');
+        $model->ensureRelationLoaded('twos.threes');
+    }
+
+    public function testWhenChildRelationIsLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+
+        $model = One::query()
+            ->with('twos.threes')
+            ->find($one->id);
+
+        $model->ensureRelationLoaded('twos.threes');
+    }
+
+    protected function expectLazyLoadingViolationException(string $modelClass, string $relation)
+    {
+        $this->expectException(LazyLoadingViolationException::class);
+        $this->expectExceptionMessage("Attempted to lazy load [$relation] on model [$modelClass] but lazy loading is disabled.");
+    }
+}
+
+class One extends Model
+{
+    public $table = 'ones';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function twos(): HasMany
+    {
+        return $this->hasMany(Two::class, 'one_id');
+    }
+}
+
+class Two extends Model
+{
+    public $table = 'twos';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function one(): BelongsTo
+    {
+        return $this->belongsTo(One::class, 'one_id');
+    }
+
+    public function threes(): HasMany
+    {
+        return $this->hasMany(Three::class, 'two_id');
+    }
+}
+
+class Three extends Model
+{
+    public $table = 'threes';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function two(): BelongsTo
+    {
+        return $this->belongsTo(Two::class, 'two_id');
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

# Add ensureRelationLoaded() method to Eloquent Model

## Why `ensureRelationLoaded()`?

Sometimes developers need to verify whether the relations are eager loaded properly to run

## Benefits

End users can define depending `\Illuminate\Database\Eloquent\Model::preventLazyLoading();`

## reasons it does not break any existing features

## how it makes building web applications easier

