### PR TITLE
Support nested relations on `relationLoaded` method

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1072,7 +1072,7 @@ trait HasRelationships
      */
     public function relationLoaded($key)
     {
-        [$relation, $childRelation] = array_replace(
+        [$relation, $nestedRelation] = array_replace(
             [null, null],
             explode('.', $key, 2),
         );
@@ -1081,9 +1081,9 @@ trait HasRelationships
             return false;
         }
 
-        if ($childRelation) {
+        if ($nestedRelation !== null) {
             foreach ($this->$relation as $related) {
-                if (! $related->relationLoaded($childRelation)) {
+                if (! $related->relationLoaded($nestedRelation)) {
                     return false;
                 }
             }

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1072,6 +1072,10 @@ trait HasRelationships
      */
     public function relationLoaded($key)
     {
+        if (array_key_exists($key, $this->relations)) {
+            return true;
+        }
+
         [$relation, $nestedRelation] = array_replace(
             [null, null],
             explode('.', $key, 2),

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1070,7 +1070,7 @@ trait HasRelationships
      * @param  string  $key
      * @return bool
      */
-    public function relationLoaded(string $key): bool
+    public function relationLoaded($key)
     {
         [$relation, $childRelation] = array_replace(
             [null, null],

--- a/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/HasRelationships.php
@@ -1070,9 +1070,26 @@ trait HasRelationships
      * @param  string  $key
      * @return bool
      */
-    public function relationLoaded($key)
+    public function relationLoaded(string $key): bool
     {
-        return array_key_exists($key, $this->relations);
+        [$relation, $childRelation] = array_replace(
+            [null, null],
+            explode('.', $key, 2),
+        );
+
+        if (! array_key_exists($relation, $this->relations)) {
+            return false;
+        }
+
+        if ($childRelation) {
+            foreach ($this->$relation as $related) {
+                if (! $related->relationLoaded($childRelation)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Integration/Database/EloquentModelRelationLoadedTest.php
+++ b/tests/Integration/Database/EloquentModelRelationLoadedTest.php
@@ -29,6 +29,32 @@ class EloquentModelRelationLoadedTest extends DatabaseTestCase
         });
     }
 
+    public function testWhenRelationIsInvalid()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+
+        $model = One::query()
+            ->with('twos')
+            ->find($one->id);
+
+        $this->assertFalse($model->relationLoaded('.'));
+        $this->assertFalse($model->relationLoaded('invalid'));
+    }
+
+    public function testWhenNestedRelationIsInvalid()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+
+        $model = One::query()
+            ->with('twos')
+            ->find($one->id);
+
+        $this->assertFalse($model->relationLoaded('twos.'));
+        $this->assertFalse($model->relationLoaded('twos.invalid'));
+    }
+
     public function testWhenRelationNotLoaded()
     {
         $one = One::query()->create();

--- a/tests/Integration/Database/EloquentModelRelationLoadedTest.php
+++ b/tests/Integration/Database/EloquentModelRelationLoadedTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Illuminate\Tests\Integration\Database\EloquentModelRelationLoadedTest;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Tests\Integration\Database\DatabaseTestCase;
+
+class EloquentModelRelationLoadedTest extends DatabaseTestCase
+{
+    protected function afterRefreshingDatabase()
+    {
+        Schema::create('ones', function (Blueprint $table) {
+            $table->increments('id');
+        });
+
+        Schema::create('twos', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('one_id');
+        });
+
+        Schema::create('threes', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('two_id');
+            $table->integer('one_id')->nullable();
+        });
+    }
+
+    public function testWhenRelationNotLoaded()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+
+        $model = One::query()->find($one->id);
+
+        $this->assertFalse($model->relationLoaded('twos'));
+    }
+
+    public function testWhenRelationLoaded()
+    {
+        $one = One::query()->create();
+        $one->twos()->create();
+
+        $model = One::query()
+            ->with('twos')
+            ->find($one->id);
+
+        $this->assertTrue($model->relationLoaded('twos'));
+    }
+
+    public function testWhenChildRelationIsNotLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+
+        $model = One::query()
+            ->with('twos')
+            ->find($one->id);
+
+        $this->assertTrue($model->relationLoaded('twos'));
+        $this->assertFalse($model->relationLoaded('twos.threes'));
+    }
+
+    public function testWhenChildRelationIsLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create();
+
+        $model = One::query()
+            ->with('twos.threes')
+            ->find($one->id);
+
+        $this->assertTrue($model->relationLoaded('twos'));
+        $this->assertTrue($model->relationLoaded('twos.threes'));
+    }
+
+    public function testWhenChildRecursiveRelationIsLoaded()
+    {
+        $one = One::query()->create();
+        $two = $one->twos()->create();
+        $two->threes()->create(['one_id' => $one->id]);
+
+        $model = One::query()
+            ->with('twos.threes.one')
+            ->find($one->id);
+
+        $this->assertTrue($model->relationLoaded('twos'));
+        $this->assertTrue($model->relationLoaded('twos.threes'));
+        $this->assertTrue($model->relationLoaded('twos.threes.one'));
+    }
+}
+
+class One extends Model
+{
+    public $table = 'ones';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function twos(): HasMany
+    {
+        return $this->hasMany(Two::class, 'one_id');
+    }
+}
+
+class Two extends Model
+{
+    public $table = 'twos';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function one(): BelongsTo
+    {
+        return $this->belongsTo(One::class, 'one_id');
+    }
+
+    public function threes(): HasMany
+    {
+        return $this->hasMany(Three::class, 'two_id');
+    }
+}
+
+class Three extends Model
+{
+    public $table = 'threes';
+    public $timestamps = false;
+    protected $guarded = [];
+
+    public function one(): BelongsTo
+    {
+        return $this->belongsTo(One::class, 'one_id');
+    }
+
+    public function two(): BelongsTo
+    {
+        return $this->belongsTo(Two::class, 'two_id');
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

# Added support to check nested relations when using `relationLoaded()` method of Eloquent Model

## Why?

Current `relationLoaded()` method only checks single level relation of the Model. Now users can check nested relations.

```
$user->load('posts.comments');

// Previously
$user->relationLoaded('posts.comments'); // Returns false

// Now
$user->relationLoaded('posts.comments'); // Returns true
```

## Benefits

End users can check whether the nested relation loaded once and load the desired relation.

## It will not break existing features

Technically this new enhancement should not break any existing usage of the method because the code is designed to support single level relation check as well.